### PR TITLE
Add `Synchronized` property wrapper and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
+## Mac files
+.DS_Store
+
 ## User settings
 xcuserdata/
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 ## Mac files
 .DS_Store
 
+## Swift Package
+.swiftpm/
+
 ## User settings
 xcuserdata/
 

--- a/ConcurrencyBooster/Extensions/Locks/NSRecursiveLock+Synchronized.swift
+++ b/ConcurrencyBooster/Extensions/Locks/NSRecursiveLock+Synchronized.swift
@@ -7,7 +7,29 @@
 
 import Foundation
 
+/// Extensions which enable usage of `synchronized`. See method documentation for details.
 public extension NSRecursiveLock {
+
+  /// Extension which allows callers to write linear code within a lock and have it automatically be released.
+  ///
+  /// Before:
+  /// ```swift
+  /// let lock = NSRecursiveLock()
+  /// let capturedValue: String
+  /// lock.lock()
+  /// executeSomeWork()
+  /// capturedValue = doSomeMoreWork()
+  /// lock.unlock()
+  /// ```
+  ///
+  /// After:
+  /// ```swift
+  /// let lock = NSRecursiveLock()
+  /// let capturedValue = lock.synchronized {
+  ///    executeSomeWork()
+  ///    return doSomeMoreWork()
+  /// }
+  /// ```
   @discardableResult
   func synchronized<T>(_ closure: () throws -> T) rethrows -> T {
     lock()

--- a/ConcurrencyBooster/Extensions/Locks/NSRecursiveLock+Synchronized.swift
+++ b/ConcurrencyBooster/Extensions/Locks/NSRecursiveLock+Synchronized.swift
@@ -1,0 +1,17 @@
+//
+//  NSRecursiveLock+Synchronized.swift
+//
+//
+//  Created by Michael Welsh on 2023-12-26.
+//
+
+import Foundation
+
+public extension NSRecursiveLock {
+  @discardableResult
+  func synchronized<T>(_ closure: () throws -> T) rethrows -> T {
+    lock()
+    defer { unlock() }
+    return try closure()
+  }
+}

--- a/ConcurrencyBooster/Features/Synchronized/Synchronized.swift
+++ b/ConcurrencyBooster/Features/Synchronized/Synchronized.swift
@@ -9,13 +9,15 @@ import Foundation
 
 /// @Synchronized guarantees thread-safety for concurrent accesses to a property.
 /// For class types, you should _not_ mutate a property that is guarded by synchronized directly - instead use the `.synchronized { }` function.
-/// - Structs may be modified directly.
+/// Structs may be modified directly.
 ///
 /// Good examples:
 ///    - `myDict[25_01_2021] = "Blobiverse"`
 ///    - `$classType.synchronized { $0.perform("string") }`
+///
 /// Bad examples:
 ///   - `classType.perform("string")`   Should NOT attempt to mutate non-atomically.
+///
 /// Structs won't let you do it anyway, but classes will—and may behave unexpectedly.
 ///
 @propertyWrapper

--- a/ConcurrencyBooster/Features/Synchronized/Synchronized.swift
+++ b/ConcurrencyBooster/Features/Synchronized/Synchronized.swift
@@ -1,0 +1,54 @@
+//
+//  Synchronized.swift
+//
+//
+//  Created by Michael Welsh on 2023-12-26.
+//
+
+import Foundation
+
+/// @Synchronized guarantees thread-safety for concurrent accesses to a property.
+/// For class types, you should _not_ mutate a property that is guarded by synchronized directly - instead use the `.synchronized { }` function.
+/// - Structs may be modified directly.
+///
+/// Good examples:
+///    - `myDict[25_01_2021] = "Blobiverse"`
+///    - `$classType.synchronized { $0.perform("string") }`
+/// Bad examples:
+///   - `classType.perform("string")`   Should NOT attempt to mutate non-atomically.
+/// Structs won't let you do it anyway, but classes will—and may behave unexpectedly.
+///
+@propertyWrapper
+public final class Synchronized<Value> {
+  // MARK: Lifecycle
+
+  public init(wrappedValue value: Value) {
+    self.value = value
+  }
+
+  // MARK: Public
+
+  public var wrappedValue: Value {
+    get {
+      lock.synchronized { value }
+    }
+    _modify {
+      lock.lock(); defer { lock.unlock() }
+      yield &value
+    }
+  }
+
+  public var projectedValue: Synchronized<Value> { self }
+
+  @discardableResult
+  public func synchronized<T>(_ closure: (inout Value) throws -> T) rethrows -> T {
+    try lock.synchronized {
+      try closure(&value)
+    }
+  }
+
+  // MARK: Private
+
+  private let lock = NSRecursiveLock()
+  private var value: Value
+}

--- a/ConcurrencyBoosterTests/Extensions/Features/Synchronized/SynchronizedTests.swift
+++ b/ConcurrencyBoosterTests/Extensions/Features/Synchronized/SynchronizedTests.swift
@@ -1,0 +1,143 @@
+//
+//  SynchronizedTests.swift
+//
+//
+//  Created by Michael Welsh on 2023-12-26.
+//
+
+import Foundation
+import ConcurrencyBooster
+import XCTest
+
+class SynchronizedTests: XCTestCase {
+  @Synchronized var sut = [String]()
+  @Synchronized var sut_dict = [Int: String]()
+  @Synchronized var sut_bool = false
+  @Synchronized var sut_set = Set<String>()
+
+  func test_renentrant_success() {
+    // Arrange
+    let first = "ONE"
+    let second = "TWO"
+    var capturedContent: [String] = []
+
+    // Act
+    // Measure runs 10 times by default.
+    measure {
+      $sut.synchronized { array in
+        array.append(first)
+        $sut.synchronized { innerArray in
+          innerArray.append(second)
+          capturedContent = innerArray
+        }
+      }
+    }
+
+    // Assert
+    XCTAssertEqual(
+      capturedContent,
+      [
+        "ONE",
+        "TWO",
+        "ONE",
+        "TWO",
+        "ONE",
+        "TWO",
+        "ONE",
+        "TWO",
+        "ONE",
+        "TWO",
+        "ONE",
+        "TWO",
+        "ONE",
+        "TWO",
+        "ONE",
+        "TWO",
+        "ONE",
+        "TWO",
+        "ONE",
+        "TWO",
+      ]
+    )
+  }
+
+  func test_concurrencyResilience() {
+    let queue = DispatchQueue.global()
+
+    let dispatchGroup = DispatchGroup()
+
+    // Act
+    for val in 0..<50_000 {
+      dispatchGroup.enter()
+      // Append content asynchronously.
+      queue.async {
+
+        self.$sut.synchronized { array in
+          array.append(String(describing: val))
+        }
+        dispatchGroup.leave()
+      }
+    }
+
+    // We use a dispatch group to keep `subject` in reference, otherwise the async above can be flaky.
+    dispatchGroup.wait()
+
+    // Assert
+    $sut.synchronized { array in
+      XCTAssertEqual(array.count, 50_000)
+    }
+  }
+
+  func test_wrappedValueRead_projectedValueConcurrentRead() {
+    DispatchQueue.concurrentPerform(iterations: 1_000) { i in
+      _ = $sut.wrappedValue
+      _ = sut
+      $sut.synchronized { $0.append("\(i)") }
+    }
+
+    XCTAssertEqual(sut.count, 1_000)
+  }
+
+  func test_wrappedValueModify_concurrentArrayAppend() {
+    DispatchQueue.concurrentPerform(iterations: 100) { i in
+      for _ in 0..<100 {
+        sut.append("\(i)")
+        sut += ["\(i)"]
+        $sut.synchronized { $0.append("\(i)") }
+      }
+    }
+    XCTAssertEqual(sut.count, 30_000)
+  }
+
+  func test_wrappedValueModify_concurrentDictionaryRemove() {
+    DispatchQueue.concurrentPerform(iterations: 10_000) { i in
+      sut_dict[i] = "\(i)"
+    }
+    DispatchQueue.concurrentPerform(iterations: 10_000) { i in
+      sut_dict.removeValue(forKey: i)
+    }
+    XCTAssertEqual(sut_dict.count, 0)
+  }
+
+  func test_wrappedValue_concurrentBooleanAssignAndRead() {
+    DispatchQueue.concurrentPerform(iterations: 10_000) { i in
+      // Assign
+      sut_bool = i % 2 == 0
+      // Read
+      _ = sut_bool
+    }
+    sut_bool = true
+    XCTAssertTrue(sut_bool)
+  }
+
+  func test_wrappedValueModify_concurrentSetRemove() {
+    DispatchQueue.concurrentPerform(iterations: 10_000) { i in
+      sut_set.insert("\(i)")
+    }
+    DispatchQueue.concurrentPerform(iterations: 10_000) { i in
+      _ = sut_set.contains("\(i)")
+      sut_set.remove("\(i)")
+    }
+    XCTAssertEqual(sut_set.count, 0)
+  }
+}

--- a/ConcurrencyBoosterTests/Extensions/Locks/NSRecursiveLock+SynchronizedTests.swift
+++ b/ConcurrencyBoosterTests/Extensions/Locks/NSRecursiveLock+SynchronizedTests.swift
@@ -1,0 +1,47 @@
+//
+//  NSRecursiveLock+SynchronizedTests.swift
+//
+//
+//  Created by Michael Welsh on 2023-12-26.
+//
+
+import Foundation
+import XCTest
+@testable import ConcurrencyBooster
+
+class NSRecursiveLock_SafelyTests: XCTestCase {
+  let sut = NSRecursiveLock()
+
+  func test_reentrant_success() {
+    // Arrange
+    var nums = [Int]()
+
+    // Act
+    // Run the test using measure to execute several times.
+    measure {
+      DispatchQueue.concurrentPerform(iterations: 100_000) { i in
+        // Recurse into the lock, calling synchronized twice.
+        sut.synchronized {
+          sut.synchronized {
+            nums.append(i)
+          }
+        }
+      }
+    }
+
+    // Assert
+    XCTAssertEqual(nums.count, 1_000_000) // measure runs 10x
+  }
+
+  func test_returnValue() {
+    // Arrange
+
+    // Act
+    let val = sut.synchronized {
+      return "JustSomeString"
+    }
+
+    // Assert
+    XCTAssertEqual(val, "JustSomeString")
+  }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version: 5.7
+
+import PackageDescription
+
+let package = Package(
+  name: "ConcurrencyBooster",
+  platforms: [
+    .iOS(.v16), .macOS(.v12), .macCatalyst(.v13),
+  ],
+  products: [
+    .library(
+      name: "ConcurrencyBooster",
+      targets: ["ConcurrencyBooster"]
+    ),
+  ],
+  targets: [
+    .target(
+      name: "ConcurrencyBooster",
+      path: "ConcurrencyBooster",
+      exclude: [],
+      swiftSettings: [
+        .unsafeFlags(["-enforce-exclusivity=unchecked"]),
+      ]
+    ),
+    .testTarget(
+      name: "ConcurrencyBoosterTests",
+      dependencies: ["ConcurrencyBooster"],
+      path: "ConcurrencyBoosterTests"
+    ),
+  ]
+)
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # ConcurrencyBooster
+
 Concurrency tools for Swift
+
+## Extensions
+`synchronized` for accessing contents with locks, allowing for linear code flow as opposed to needing to maintain locking states.
+
+## Features
+- `@Synchronized` property annotation, to allow safe access to properties. Simimlar to Objective-C `atomic` properties.


### PR DESCRIPTION
- Also adds `NSRecursiveLock+Synchronized`, which is used internally by the `@Synchronized` wrapper
- Updates the README and .gitignore as well